### PR TITLE
pass PgConnection into run function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "1.4.6", features = ["postgres", "serde_json", "chrono", "uuidv07"] }
+diesel = { version = "1.4.6", features = ["postgres", "serde_json", "chrono", "uuidv07", "r2d2"] }
 diesel-derive-enum = { version = "1", features = ["postgres"] }
 dotenv = "0.15.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Background job processing library for Rust. It uses Postgres DB as a task queue.
 
+Note that the README follows the master branch, to see instructions for the latest published version, check [crates.io](https://crates.io/crates/fang).
+
+
 ## Installation
 
 1. Add this to your Cargo.toml

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,11 +1,12 @@
 use crate::queue::Queue;
 use crate::queue::Task;
 use diesel::pg::PgConnection;
+use diesel::r2d2::{ConnectionManager, PooledConnection};
 use std::thread;
 use std::time::Duration;
 
 pub struct Executor {
-    pub storage: Queue,
+    pub pooled_connection: PooledConnection<ConnectionManager<PgConnection>>,
     pub task_type: Option<String>,
     pub sleep_params: SleepParams,
     pub retention_mode: RetentionMode,
@@ -66,9 +67,9 @@ pub trait Runnable {
 }
 
 impl Executor {
-    pub fn new(storage: Queue) -> Self {
+    pub fn new(pooled_connection: PooledConnection<ConnectionManager<PgConnection>>) -> Self {
         Self {
-            storage,
+            pooled_connection,
             sleep_params: SleepParams::default(),
             retention_mode: RetentionMode::RemoveFinished,
             task_type: None,
@@ -95,7 +96,7 @@ impl Executor {
 
     pub fn run_tasks(&mut self) {
         loop {
-            match self.storage.fetch_and_touch(&self.task_type.clone()) {
+            match Queue::fetch_and_touch_query(&self.pooled_connection, &self.task_type.clone()) {
                 Ok(Some(task)) => {
                     self.maybe_reset_sleep_period();
                     self.run(task);
@@ -125,7 +126,7 @@ impl Executor {
 
     fn execute_task(&self, task: Task) -> Result<Task, (Task, String)> {
         let actual_task: Box<dyn Runnable> = serde_json::from_value(task.metadata.clone()).unwrap();
-        let task_result = actual_task.run(&self.storage.connection);
+        let task_result = actual_task.run(&self.pooled_connection);
 
         match task_result {
             Ok(()) => Ok(task),
@@ -137,22 +138,26 @@ impl Executor {
         match self.retention_mode {
             RetentionMode::KeepAll => {
                 match result {
-                    Ok(task) => self.storage.finish_task(&task).unwrap(),
-                    Err((task, error)) => self.storage.fail_task(&task, error).unwrap(),
+                    Ok(task) => Queue::finish_task_query(&self.pooled_connection, &task).unwrap(),
+                    Err((task, error)) => {
+                        Queue::fail_task_query(&self.pooled_connection, &task, error).unwrap()
+                    }
                 };
             }
             RetentionMode::RemoveAll => {
                 match result {
-                    Ok(task) => self.storage.remove_task(task.id).unwrap(),
-                    Err((task, _error)) => self.storage.remove_task(task.id).unwrap(),
+                    Ok(task) => Queue::remove_task_query(&self.pooled_connection, task.id).unwrap(),
+                    Err((task, _error)) => {
+                        Queue::remove_task_query(&self.pooled_connection, task.id).unwrap()
+                    }
                 };
             }
             RetentionMode::RemoveFinished => match result {
                 Ok(task) => {
-                    self.storage.remove_task(task.id).unwrap();
+                    Queue::remove_task_query(&self.pooled_connection, task.id).unwrap();
                 }
                 Err((task, error)) => {
-                    self.storage.fail_task(&task, error).unwrap();
+                    Queue::fail_task_query(&self.pooled_connection, &task, error).unwrap();
                 }
             },
         }
@@ -172,6 +177,7 @@ mod executor_tests {
     use crate::{Deserialize, Serialize};
     use diesel::connection::Connection;
     use diesel::pg::PgConnection;
+    use diesel::r2d2::{ConnectionManager, PooledConnection};
 
     #[derive(Serialize, Deserialize)]
     struct ExecutorJobTest {
@@ -244,20 +250,20 @@ mod executor_tests {
             task_type: "common".to_string(),
         };
 
-        let mut executor = Executor::new(Queue::new());
+        let mut executor = Executor::new(pooled_connection());
         executor.set_retention_mode(RetentionMode::KeepAll);
 
         executor
-            .storage
-            .connection
+            .pooled_connection
             .test_transaction::<(), Error, _>(|| {
-                let task = executor.storage.insert(&new_task).unwrap();
+                let task = Queue::insert_query(&executor.pooled_connection, &new_task).unwrap();
 
                 assert_eq!(FangTaskState::New, task.state);
 
                 executor.run(task.clone());
 
-                let found_task = executor.storage.find_task_by_id(task.id).unwrap();
+                let found_task =
+                    Queue::find_task_by_id_query(&executor.pooled_connection, task.id).unwrap();
 
                 assert_eq!(FangTaskState::Finished, found_task.state);
 
@@ -281,17 +287,16 @@ mod executor_tests {
             task_type: "type2".to_string(),
         };
 
-        let executor = Executor::new(Queue::new());
+        let executor = Executor::new(pooled_connection());
 
-        let task1 = executor.storage.insert(&new_task1).unwrap();
-        let task2 = executor.storage.insert(&new_task2).unwrap();
+        let task1 = Queue::insert_query(&executor.pooled_connection, &new_task1).unwrap();
+        let task2 = Queue::insert_query(&executor.pooled_connection, &new_task2).unwrap();
 
         assert_eq!(FangTaskState::New, task1.state);
         assert_eq!(FangTaskState::New, task2.state);
 
         std::thread::spawn(move || {
-            let queue = Queue::new();
-            let mut executor = Executor::new(queue);
+            let mut executor = Executor::new(pooled_connection());
             executor.set_retention_mode(RetentionMode::KeepAll);
             executor.set_task_type("type1".to_string());
 
@@ -300,10 +305,12 @@ mod executor_tests {
 
         std::thread::sleep(std::time::Duration::from_millis(1000));
 
-        let found_task1 = executor.storage.find_task_by_id(task1.id).unwrap();
+        let found_task1 =
+            Queue::find_task_by_id_query(&executor.pooled_connection, task1.id).unwrap();
         assert_eq!(FangTaskState::Finished, found_task1.state);
 
-        let found_task2 = executor.storage.find_task_by_id(task2.id).unwrap();
+        let found_task2 =
+            Queue::find_task_by_id_query(&executor.pooled_connection, task2.id).unwrap();
         assert_eq!(FangTaskState::New, found_task2.state);
     }
 
@@ -316,19 +323,19 @@ mod executor_tests {
             task_type: "common".to_string(),
         };
 
-        let executor = Executor::new(Queue::new());
+        let executor = Executor::new(pooled_connection());
 
         executor
-            .storage
-            .connection
+            .pooled_connection
             .test_transaction::<(), Error, _>(|| {
-                let task = executor.storage.insert(&new_task).unwrap();
+                let task = Queue::insert_query(&executor.pooled_connection, &new_task).unwrap();
 
                 assert_eq!(FangTaskState::New, task.state);
 
                 executor.run(task.clone());
 
-                let found_task = executor.storage.find_task_by_id(task.id).unwrap();
+                let found_task =
+                    Queue::find_task_by_id_query(&executor.pooled_connection, task.id).unwrap();
 
                 assert_eq!(FangTaskState::Failed, found_task.state);
                 assert_eq!(
@@ -338,5 +345,9 @@ mod executor_tests {
 
                 Ok(())
             });
+    }
+
+    fn pooled_connection() -> PooledConnection<ConnectionManager<PgConnection>> {
+        Queue::connection_pool(5).get().unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,12 @@ extern crate log;
 mod schema;
 
 pub mod executor;
-pub mod postgres;
+pub mod queue;
 pub mod scheduler;
 pub mod worker_pool;
 
 pub use executor::*;
-pub use postgres::*;
+pub use queue::*;
 pub use scheduler::*;
 pub use worker_pool::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::nonstandard_macro_braces)]
 
 #[macro_use]
-extern crate diesel;
+pub extern crate diesel;
 
 #[macro_use]
 extern crate log;
@@ -18,6 +18,8 @@ pub use queue::*;
 pub use scheduler::*;
 pub use worker_pool::*;
 
+#[doc(hidden)]
+pub use diesel::pg::PgConnection;
 #[doc(hidden)]
 pub use serde::{Deserialize, Serialize};
 #[doc(hidden)]

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -214,14 +214,12 @@ mod job_pool_tests {
 
     #[typetag::serde]
     impl Runnable for MyJob {
-        fn run(&self, _connection: &PgConnection) -> Result<(), Error> {
-            let queue = Queue::new();
-
+        fn run(&self, connection: &PgConnection) -> Result<(), Error> {
             thread::sleep(Duration::from_secs(3));
 
             let new_job = MyJob::new(self.number + 1);
 
-            queue.push_task(&new_job).unwrap();
+            Queue::push_task_query(connection, &new_job).unwrap();
 
             Ok(())
         }


### PR DESCRIPTION
Changes:

- maintain ConnectionPool for Worker Threads
- rename Postgres into Queue
- pass PgConnection into run function
- add function to remove all tasks of the specified type
