### PR TITLE
Support graceful shutdown of worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fang"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Ayrat Badykov <ayratin555@gmail.com>"]
 description = "Background job processing library for Rust"
 repository = "https://github.com/ayrat555/fang"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = "1.0"
 typetag = "0.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.29"

--- a/README.md
+++ b/README.md
@@ -231,6 +231,28 @@ In the example above, `push_periodic_task` is used to save the specified task to
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
+### Running tests locally
+
+```
+cargo install diesel_cli
+
+docker run --rm -d --name postgres -p 5432:5432 \
+  -e POSTGRES_DB=fang \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  postgres:latest
+
+DATABASE_URL=postgres://postgres:postgres@localhost/fang diesel migration run
+
+// Run regular tests
+cargo test --all-features
+
+// Run dirty/long tests, DB must be recreated afterwards
+cargo test --all-features -- --ignored --test-threads=1
+
+docker kill postgres
+```
+
 ## Author
 
 Ayrat Badykov (@ayrat555)

--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ use fang::WorkerPool;
 WorkerPool::new(10).start();
 ```
 
+Using a library like [signal-hook][signal-hook], it's possible to gracefully shutdown a worker. See the
+Simple Worker for an example implementation.
 
 Check out:
 
-- [simple example](https://github.com/ayrat555/fang/tree/master/fang_examples/simple_worker) - simple worker example
+- [Simple Worker Example](https://github.com/ayrat555/fang/tree/master/fang_examples/simple_worker) - simple worker example
 - [El Monitorro](https://github.com/ayrat555/el_monitorro) - telegram feed reader. It uses Fang to synchronize feeds and deliver updates to users.
 
 ### Configuration
@@ -264,3 +266,4 @@ Ayrat Badykov (@ayrat555)
 [docs]: https://docs.rs/fang/
 [ga-test]: https://github.com/ayrat555/fang/actions/workflows/rust.yml/badge.svg
 [ga-style]: https://github.com/ayrat555/fang/actions/workflows/style.yml/badge.svg
+[signal-hook]: https://crates.io/crates/signal-hook

--- a/fang_examples/simple_worker/Cargo.toml
+++ b/fang_examples/simple_worker/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2018"
 [dependencies]
 fang = { path = "../../" }
 serde = { version = "1.0", features = ["derive"] }
+signal-hook = "0.3.10"
 dotenv = "0.15.0"
 env_logger = "0.9.0"

--- a/fang_examples/simple_worker/src/main.rs
+++ b/fang_examples/simple_worker/src/main.rs
@@ -4,6 +4,7 @@ use fang::RetentionMode;
 use fang::WorkerParams;
 use fang::WorkerPool;
 use simple_worker::MyJob;
+use signal_hook::{consts::signal::*, iterator::Signals};
 
 fn main() {
     dotenv().ok();
@@ -13,12 +14,28 @@ fn main() {
     let mut worker_params = WorkerParams::new();
     worker_params.set_retention_mode(RetentionMode::KeepAll);
 
-    WorkerPool::new_with_params(2, worker_params).start();
+    let mut worker_pool = WorkerPool::new_with_params(2, worker_params);
+    worker_pool.start().unwrap();
 
     let queue = Queue::new();
 
     queue.push_task(&MyJob::new(1)).unwrap();
     queue.push_task(&MyJob::new(1000)).unwrap();
 
-    std::thread::park();
+    let mut signals = Signals::new(&[SIGINT, SIGTERM]).unwrap();
+    for sig in signals.forever() {
+        match sig {
+            SIGINT => {
+                println!("Received SIGINT");
+                worker_pool.shutdown().unwrap();
+                break;
+            },
+            SIGTERM => {
+                println!("Received SIGTERM");
+                worker_pool.shutdown().unwrap();
+                break;
+            },
+            _ => unreachable!(format!("Received unexpected signal: {:?}", sig)),
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,14 @@
+use std::io::Error as IoError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FangError {
+    #[error("The shared state in an executor thread became poisoned")]
+    SharedStatePoisoned,
+
+    #[error("Failed to create executor thread")]
+    ExecutorThreadCreationFailed {
+        #[from]
+        source: IoError,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,21 @@
 use std::io::Error as IoError;
+use std::sync::PoisonError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum FangError {
     #[error("The shared state in an executor thread became poisoned")]
-    SharedStatePoisoned,
+    PoisonedLock,
 
     #[error("Failed to create executor thread")]
     ExecutorThreadCreationFailed {
         #[from]
         source: IoError,
     },
+}
+
+impl<T> From<PoisonError<T>> for FangError {
+    fn from(_: PoisonError<T>) -> Self {
+        Self::PoisonedLock
+    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -106,9 +106,8 @@ impl Executor {
         loop {
             if let Some(ref shared_state) = self.shared_state {
                 let shared_state = shared_state.read()?;
-                match *shared_state {
-                    Some(WorkerState::Shutdown) => return Ok(()),
-                    None => {}
+                if let WorkerState::Shutdown = *shared_state {
+                    return Ok(());
                 }
             }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -105,9 +105,7 @@ impl Executor {
     pub fn run_tasks(&mut self) -> Result<(), FangError> {
         loop {
             if let Some(ref shared_state) = self.shared_state {
-                let shared_state = shared_state
-                    .read()
-                    .map_err(|_| FangError::SharedStatePoisoned)?;
+                let shared_state = shared_state.read()?;
                 match *shared_state {
                     Some(WorkerState::Shutdown) => return Ok(()),
                     None => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,14 @@
 #[macro_use]
 extern crate diesel;
 
+pub mod error;
 pub mod executor;
 pub mod queue;
 pub mod scheduler;
 pub mod schema;
 pub mod worker_pool;
 
+pub use error::FangError;
 pub use executor::*;
 pub use queue::*;
 pub use scheduler::*;

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -20,7 +20,6 @@ pub struct WorkerPool {
     thread_join_handles: Arc<RwLock<HashMap<String, thread::JoinHandle<()>>>>,
 }
 
-#[derive(Clone)]
 pub struct WorkerThread {
     pub name: String,
     pub restarts: u64,
@@ -144,19 +143,19 @@ impl WorkerThread {
         name: String,
         restarts: u64,
         worker_pool: WorkerPool,
-    ) -> Result<WorkerThread, FangError> {
+    ) -> Result<(), FangError> {
         info!(
             "starting a worker thread {}, number of restarts {}",
             name, restarts
         );
 
         let job = WorkerThread::new(name.clone(), restarts, worker_pool.clone());
-        let join_handle = Self::spawn_thread(name.clone(), job.clone())?;
-        job.worker_pool
+        let join_handle = Self::spawn_thread(name.clone(), job)?;
+        worker_pool
             .thread_join_handles
             .write()?
             .insert(name, join_handle);
-        Ok(job)
+        Ok(())
     }
 
     fn spawn_thread(


### PR DESCRIPTION
Did some work to support gracefully exiting individual worker threads, leaving tasks half finished. Even though tasks *should* be idempotent, supporting graceful shutdown during normal scale-down events is useful. This PR allows currently running tasks to finish before allowing the process to exit.

Also added `thiserror` and a `FangError` enum to allow Fang to return structured errors.
Bumped version to 0.5.0 as I added the `WorkerPool::shutdown` public method, as well as updated `WorkerPool::start` to return a `Result` with a `FangError`.

Here's an example usage:
```rust
use fang::WorkerPool;
use signal_hook::{consts::signal::*, iterator::Signals};

fn main() {
    let mut job_pool = WorkerPool::new(10);
    job_pool.start().unwrap();

    let mut signals = Signals::new(&[SIGINT, SIGTERM])?;
    for sig in signals.forever() {
        match sig {
            SIGINT => {
                println!("Received SIGINT");
                job_pool.shutdown().unwrap();
                break;
            },
            SIGTERM => {
                println!("Received SIGTERM");
                job_pool.shutdown().unwrap();
                break;
            },
            _ => unreachable!(format!("Received unexpected signal: {:?}", sig)),
        }
    }
}
```