### PR TITLE
fix Error struct export for `asynk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1 (2022-08-04)
+
+- Fix a conflict in exports of the `blocking` and the `asynk` features - [#61](https://github.com/ayrat555/fang/pull/61)
+
 ## 0.7.0 (2022-08-03)
 
 ### [#21](https://github.com/ayrat555/fang/pull/21)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fang"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Ayrat Badykov <ayratin555@gmail.com>" , "Pepe Márquez <pepe.marquezromero@gmail.com>"]
 description = "Background job processing library for Rust"
 repository = "https://github.com/ayrat555/fang"
@@ -45,7 +45,6 @@ optional = true
 version = "0.8"
 features = ["with-serde_json-1" , "with-uuid-0_8" , "with-chrono-0_4"]
 optional = true
-
 
 [dependencies.postgres-types]
 version = "0.X.X"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Background task processing library for Rust. It uses Postgres DB as a task queue.
 
-## Features 
+## Features
 - Asynk feature uses `tokio`. Workers are started in tokio tasks.
 - Blocking feature uses `std::thread`. Workers are started in a separated threads.
 
@@ -18,14 +18,20 @@ Background task processing library for Rust. It uses Postgres DB as a task queue
 #### Blocking feature
 ```toml
 [dependencies]
-fang = { version = "0.7" , features = ["blocking"]}
+fang = { version = "0.7" , features = ["blocking"], default-features = false }
 ```
 
 #### Asynk feature
 ```toml
 [dependencies]
-fang = { version = "0.7" , features = ["asynk"]}
+fang = { version = "0.7" , features = ["asynk"], default-features = false }
 ```
+
+#### Both features
+```toml
+fang = { version = "0.7" }
+```
+
 *Supports rustc 1.62+*
 
 2. Create `fang_tasks` table in the Postgres database. The migration can be found in [the migrations directory](https://github.com/ayrat555/fang/blob/master/migrations/2021-06-05-112912_create_fang_tasks/up.sql).
@@ -68,7 +74,7 @@ The second parameter  of the `run` function is diesel's PgConnection, You can re
 #### Asynk feature
 Every task should implement `fang::AsyncRunnable` trait which is used by `fang` to execute it.
 
-Also be careful to not to call with the same name two impl of AsyncRunnable, because will cause a fail with typetag. 
+Also be careful to not to call with the same name two impl of AsyncRunnable, because will cause a fail with typetag.
 ```rust
 use fang::AsyncRunnable;
 use fang::asynk::async_queue::AsyncQueueable;
@@ -87,7 +93,7 @@ impl AsyncRunnable for AsyncTask {
     async fn run(&self, _queueable: &mut dyn AsyncQueueable) -> Result<(), Error> {
         Ok(())
     }
-    // this func is optional to impl 
+    // this func is optional to impl
     // Default task-type it is common
     fn task_type(&self) -> String {
         "my-task-type".to_string()
@@ -142,7 +148,7 @@ let max_pool_size: u32 = 2;
 let mut queue = AsyncQueue::builder()
     // Postgres database url
     .uri("postgres://postgres:postgres@localhost/fang")
-    // Max number of connections that are allowed 
+    // Max number of connections that are allowed
     .max_pool_size(max_pool_size)
     // false if would like Uniqueness in tasks
     .duplicated_tasks(true)
@@ -373,7 +379,7 @@ use fang::asynk::async_scheduler::Scheduler;
 use fang::asynk::async_queue::AsyncQueueable;
 use fang::asynk::async_queue::AsyncQueue;
 
-// Build a AsyncQueue as before 
+// Build a AsyncQueue as before
 
 let schedule_in_future = Utc::now() + OtherDuration::seconds(5);
 
@@ -395,7 +401,7 @@ let mut scheduler = Scheduler::builder()
 
 // Add some more task in other thread or before loop
 
-// Scheduler Loop 
+// Scheduler Loop
 scheduler.start().await.unwrap();
 ```
 
@@ -433,7 +439,7 @@ docker kill postgres
 ## Authors
 
 - Ayrat Badykov (@ayrat555)
- 
+
 - Pepe Márquez (@pxp9)
 
 

--- a/src/asynk/async_queue.rs
+++ b/src/asynk/async_queue.rs
@@ -776,8 +776,8 @@ mod async_queue_tests {
     use super::AsyncQueueable;
     use super::FangTaskState;
     use super::Task;
+    use crate::asynk::AsyncError as Error;
     use crate::asynk::AsyncRunnable;
-    use crate::asynk::Error;
     use async_trait::async_trait;
     use bb8_postgres::bb8::Pool;
     use bb8_postgres::tokio_postgres::NoTls;

--- a/src/asynk/async_queue.rs
+++ b/src/asynk/async_queue.rs
@@ -1,11 +1,9 @@
+use crate::asynk::async_runnable::AsyncRunnable;
 use crate::asynk::async_runnable::Error as FangError;
-use crate::AsyncRunnable;
 use async_trait::async_trait;
 use bb8_postgres::bb8::Pool;
 use bb8_postgres::bb8::RunError;
 use bb8_postgres::tokio_postgres::row::Row;
-#[cfg(test)]
-use bb8_postgres::tokio_postgres::tls::NoTls;
 use bb8_postgres::tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 use bb8_postgres::tokio_postgres::Socket;
 use bb8_postgres::tokio_postgres::Transaction;
@@ -17,6 +15,9 @@ use postgres_types::{FromSql, ToSql};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
+
+#[cfg(test)]
+use bb8_postgres::tokio_postgres::tls::NoTls;
 
 const INSERT_TASK_QUERY: &str = include_str!("queries/insert_task.sql");
 const INSERT_PERIODIC_TASK_QUERY: &str = include_str!("queries/insert_periodic_task.sql");
@@ -333,6 +334,7 @@ impl AsyncQueueable for AsyncQueueTest<'_> {
         Ok(task)
     }
 }
+
 impl<Tls> AsyncQueue<Tls>
 where
     Tls: MakeTlsConnect<Socket> + Clone + Send + Sync + 'static,
@@ -463,6 +465,7 @@ where
         let task = Self::row_to_task(row);
         Ok(task)
     }
+
     async fn schedule_next_task_query(
         transaction: &mut Transaction<'_>,
         periodic_task: PeriodicTask,
@@ -477,6 +480,7 @@ where
         let periodic_task = Self::row_to_periodic_task(row);
         Ok(periodic_task)
     }
+
     async fn insert_periodic_task_query(
         transaction: &mut Transaction<'_>,
         metadata: serde_json::Value,
@@ -516,6 +520,7 @@ where
             Ok(Some(periodic_tasks))
         }
     }
+
     async fn execute_query(
         transaction: &mut Transaction<'_>,
         query: &str,
@@ -545,6 +550,7 @@ where
             None => Self::insert_task_query(transaction, metadata, task_type).await,
         }
     }
+
     async fn find_task_by_metadata_query(
         transaction: &mut Transaction<'_>,
         metadata: &serde_json::Value,
@@ -558,6 +564,7 @@ where
             Err(_) => None,
         }
     }
+
     fn row_to_periodic_task(row: Row) -> PeriodicTask {
         let id: Uuid = row.get("id");
         let metadata: serde_json::Value = row.get("metadata");
@@ -578,6 +585,7 @@ where
             .updated_at(updated_at)
             .build()
     }
+
     fn row_to_task(row: Row) -> Task {
         let id: Uuid = row.get("id");
         let metadata: serde_json::Value = row.get("metadata");

--- a/src/asynk/async_scheduler.rs
+++ b/src/asynk/async_scheduler.rs
@@ -169,8 +169,8 @@ mod async_scheduler_tests {
     use crate::asynk::async_queue::AsyncQueueTest;
     use crate::asynk::async_queue::AsyncQueueable;
     use crate::asynk::async_queue::PeriodicTask;
+    use crate::asynk::AsyncError as Error;
     use crate::asynk::AsyncRunnable;
-    use crate::asynk::Error;
     use async_trait::async_trait;
     use bb8_postgres::bb8::Pool;
     use bb8_postgres::tokio_postgres::NoTls;

--- a/src/asynk/async_scheduler.rs
+++ b/src/asynk/async_scheduler.rs
@@ -1,7 +1,7 @@
 use crate::asynk::async_queue::AsyncQueueable;
 use crate::asynk::async_queue::PeriodicTask;
+use crate::asynk::AsyncError as Error;
 use crate::asynk::AsyncRunnable;
-use crate::asynk::Error;
 use async_recursion::async_recursion;
 use log::error;
 use std::time::Duration;

--- a/src/asynk/async_worker.rs
+++ b/src/asynk/async_worker.rs
@@ -216,8 +216,8 @@ mod async_worker_tests {
     use crate::asynk::async_queue::AsyncQueueable;
     use crate::asynk::async_queue::FangTaskState;
     use crate::asynk::async_worker::Task;
+    use crate::asynk::AsyncError as Error;
     use crate::asynk::AsyncRunnable;
-    use crate::asynk::Error;
     use crate::RetentionMode;
     use async_trait::async_trait;
     use bb8_postgres::bb8::Pool;

--- a/src/asynk/async_worker.rs
+++ b/src/asynk/async_worker.rs
@@ -3,7 +3,7 @@ use crate::asynk::async_queue::FangTaskState;
 use crate::asynk::async_queue::Task;
 use crate::asynk::async_queue::DEFAULT_TASK_TYPE;
 use crate::asynk::async_runnable::AsyncRunnable;
-use crate::asynk::Error;
+use crate::asynk::AsyncError as Error;
 use crate::{RetentionMode, SleepParams};
 use log::error;
 use std::time::Duration;

--- a/src/asynk/async_worker_pool.rs
+++ b/src/asynk/async_worker_pool.rs
@@ -1,6 +1,6 @@
 use crate::asynk::async_queue::AsyncQueueable;
 use crate::asynk::async_worker::AsyncWorker;
-use crate::asynk::Error;
+use crate::asynk::AsyncError as Error;
 use crate::{RetentionMode, SleepParams};
 use async_recursion::async_recursion;
 use log::error;

--- a/src/asynk/mod.rs
+++ b/src/asynk/mod.rs
@@ -5,4 +5,4 @@ pub mod async_worker;
 pub mod async_worker_pool;
 
 pub use async_runnable::AsyncRunnable;
-pub use async_runnable::Error;
+pub use async_runnable::Error as AsyncError;


### PR DESCRIPTION
There conflicts with blocking module's Error struct

```rust
15 | use fang::Error as FangError;
   |     ^^^^^^-----^^^^^^^^^^^^^
   |     |     |
   |     |     help: a similar name exists in the module: `error`
   |     no `Error` in the root

```
