### PR TITLE
Update crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.10.2 (2023-02-23)
+
+### Improved
+
+- update `diesel-derive-enum` from `2.0.0-rc.0` to `2.0.1` - [#111](https://github.com/ayrat555/fang/pull/111)
+- use `dotenvy` instead of `dotenv` - [#111](https://github.com/ayrat555/fang/pull/111)
+- update `tokio` from `1.20` to `1.25` - [#111](https://github.com/ayrat555/fang/pull/111)
+
 ## 0.10.1 (2023-02-03)
 
 ### Improved

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fang"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ayrat Badykov <ayratin555@gmail.com>" , "Pepe Márquez <pepe.marquezromero@gmail.com>"]
 description = "Background job processing library for Rust"
 repository = "https://github.com/ayrat555/fang"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [features]
 default = ["blocking", "asynk"]
-blocking = ["diesel", "diesel-derive-enum", "dotenv"]
+blocking = ["diesel", "diesel-derive-enum", "dotenvy"]
 asynk = ["bb8-postgres",  "postgres-types", "tokio", "async-trait", "async-recursion"]
 
 [dependencies]
@@ -24,9 +24,9 @@ cron = "0.12"
 chrono = "0.4"
 hex = "0.4"
 log = "0.4"
-serde = "1"
-serde_derive = "1.0.141"
-serde_json = "1"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 sha2 = "0.10"
 thiserror = "1.0"
 typed-builder = "0.12"
@@ -39,11 +39,11 @@ features = ["postgres", "serde_json", "chrono", "uuid", "r2d2"]
 optional = true
 
 [dependencies.diesel-derive-enum]
-version = "2.0.0-rc.0"
+version = "2.0.1"
 features = ["postgres"]
 optional = true
 
-[dependencies.dotenv]
+[dependencies.dotenvy]
 version = "0.15"
 optional = true
 
@@ -58,14 +58,13 @@ features = ["derive"]
 optional = true
 
 [dependencies.tokio]
-version = "1.20"
+version = "1.25"
 features = ["rt", "time", "macros"]
 optional = true
 
 [dependencies.async-trait]
 version = "0.1"
 optional = true
-
 
 [dependencies.async-recursion]
 version = "1"

--- a/fang_examples/blocking/simple_worker/src/main.rs
+++ b/fang_examples/blocking/simple_worker/src/main.rs
@@ -1,5 +1,5 @@
 use diesel::r2d2;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use fang::PgConnection;
 use fang::Queue;
 use fang::Queueable;

--- a/src/blocking/fang_task_state.rs
+++ b/src/blocking/fang_task_state.rs
@@ -1,6 +1,6 @@
 /// Possible states of the task
 #[derive(diesel_derive_enum::DbEnum, Debug, Eq, PartialEq, Clone)]
-#[DieselTypePath = "crate::schema::sql_types::FangTaskState"]
+#[ExistingTypePath = "crate::schema::sql_types::FangTaskState"]
 pub enum FangTaskState {
     /// The task is ready to be executed
     New,

--- a/src/blocking/queue.rs
+++ b/src/blocking/queue.rs
@@ -22,7 +22,7 @@ use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 #[cfg(test)]
-use dotenv::dotenv;
+use dotenvy::dotenv;
 #[cfg(test)]
 use std::env;
 


### PR DESCRIPTION
- update `diesel-derive-enum` from `2.0.0-rc.0` to `2.0.1`
- use `dotenvy` instead of `dotenv`
- update `tokio` from `1.20` to `1.25`