### PR TITLE
blocking: Use the default task type

### DIFF
--- a/src/blocking/worker_pool.rs
+++ b/src/blocking/worker_pool.rs
@@ -1,4 +1,5 @@
 use crate::queue::Queueable;
+use crate::runnable::COMMON_TYPE;
 use crate::worker::Worker;
 use crate::FangError;
 use crate::RetentionMode;
@@ -27,7 +28,7 @@ where
     #[builder(setter(into))]
     pub number_of_workers: u32,
     /// The type of tasks that will be executed by `AsyncWorkerPool`.
-    #[builder(setter(into), default)]
+    #[builder(setter(into), default=COMMON_TYPE.into())]
     pub task_type: String,
 }
 


### PR DESCRIPTION
Ensure that the default task type is set on the worker pool if one isn't provided to the builder