### PR TITLE
Use `dep:` prefix in feature dependencies

### DIFF
--- a/fang/Cargo.toml
+++ b/fang/Cargo.toml
@@ -16,9 +16,9 @@ doctest = false
 
 [features]
 default = ["blocking", "asynk", "derive-error"]
-blocking = ["diesel", "diesel-derive-enum", "dotenvy"]
-asynk = ["bb8-postgres",  "postgres-types", "tokio", "async-trait", "async-recursion"]
-derive-error = ["fang-derive-error"]
+blocking = ["dep:diesel", "dep:diesel-derive-enum", "dep:dotenvy"]
+asynk = ["dep:bb8-postgres", "dep:postgres-types", "dep:tokio", "dep:async-trait", "dep:async-recursion"]
+derive-error = ["dep:fang-derive-error"]
 
 [dev-dependencies]
 fang-derive-error = { version = "0.1.0"}


### PR DESCRIPTION
This prevents users from manually enabling optional dependencies as if they were features.

Without this, the following `Cargo.toml` would be valid:

```toml
[package]
name = "some-package"
version = "0.1.0"

[dependencies]
fang = { version = "0.10.4" , default-features = false, features = ["bb8-postgres"]}
```

[The Cargo Book](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies) recomends this.