### PR TITLE
Fix conditional compilation of diesel macros

### DIFF
--- a/fang/src/lib.rs
+++ b/fang/src/lib.rs
@@ -149,7 +149,7 @@ impl From<FangTaskState> for &str {
 
 #[derive(Debug, Eq, PartialEq, Clone, TypedBuilder)]
 #[cfg_attr(feature = "blocking", derive(Queryable, Identifiable))]
-#[diesel(table_name = fang_tasks)]
+#[cfg_attr(feature = "blocking", diesel(table_name = fang_tasks))]
 pub struct Task {
     #[builder(setter(into))]
     pub id: Uuid,


### PR DESCRIPTION
With `0.11.0-rc1`, bcbb48d5af48018ae2ff0177ccf36ed46d4635c0 specifically, a bug was introduced, causing one `diesel` macro not being excluded from compilation even if the `blocking` feature is not enabled. The line added in the referenced commit is: https://github.com/ayrat555/fang/blame/2847db35a690f3c58d5e26bb48bf2c1418cf4849/fang/src/lib.rs#L152

The resulting error when trying to compile with
```toml
fang = { version = "0.11.0-rc1", features = ["asynk-postgres"], default-features = false }
```
is:
```bash
error: cannot find attribute `diesel` in this scope
   --> /Users/.../.cargo/registry/src/index.crates.io-6f17d22bba15001f/fang-0.11.0-rc1/src/lib.rs:152:3
    |
152 | #[diesel(table_name = fang_tasks)]
    |   ^^^^^^

error: could not compile `fang` (lib) due to 1 previous error
error: Recipe `build-...` failed on line 103 with exit code 101
```

The solution I suggest is to only include this instance of the diesel macro when the blocking feature is enabled.