### PR TITLE
fix: broken example

### DIFF
--- a/fang/fang_examples/asynk/simple_cron_async_worker/src/lib.rs
+++ b/fang/fang_examples/asynk/simple_cron_async_worker/src/lib.rs
@@ -13,7 +13,7 @@ pub struct MyCronTask {}
 #[async_trait]
 #[typetag::serde]
 impl AsyncRunnable for MyCronTask {
-    async fn run(&self, _queue: &dyn AsyncQueueable) -> Result<(), FangError> {
+    async fn run(&self, _queue: &mut dyn AsyncQueueable) -> Result<(), FangError> {
         log::info!("CRON!!!!!!!!!!!!!!!",);
 
         Ok(())


### PR DESCRIPTION
this example was broken because the signature of `AsyncRunnable::run` declared the queue as `&mut dyn AsyncQueuable`