### PR TITLE
Refresh deps and example

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy to gh-pages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         ref: 'master'
         submodules: 'recursive'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
 
       - name: Setup Rust
@@ -64,7 +64,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -94,7 +94,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -135,7 +135,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -165,7 +165,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -198,7 +198,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
 
@@ -237,7 +237,7 @@ jobs:
           - 3306:3306
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,7 @@ jobs:
         toolchain:
           - stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/fang/Cargo.toml
+++ b/fang/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fang"
-version = "0.11.0-rc1"
-authors = ["Ayrat Badykov <ayratin555@gmail.com>" , "Pepe Márquez <pepe.marquezromero@gmail.com>"]
+version = "0.11.0-rc2"
+authors = [
+  "Ayrat Badykov <ayratin555@gmail.com>",
+  "Pepe Márquez <pepe.marquezromero@gmail.com>",
+]
 description = "Background job processing library for Rust"
 repository = "https://github.com/ayrat555/fang"
 edition = "2021"
@@ -15,17 +18,35 @@ rust-version = "1.77"
 doctest = false
 
 [features]
-default = ["blocking", "asynk-sqlx", "derive-error", "blocking-postgres", "blocking-mysql" , "blocking-sqlite", "migrations-postgres", "migrations-sqlite", "migrations-mysql"]
-asynk-postgres = ["asynk-sqlx" , "sqlx?/postgres"]
-asynk-sqlite = ["asynk-sqlx" , "sqlx?/sqlite"]
-asynk-mysql = ["asynk-sqlx"  , "sqlx?/mysql"]
-asynk-sqlx = ["asynk" , "dep:sqlx"]
-asynk = ["dep:tokio", "dep:async-trait", "dep:async-recursion" ]
+default = [
+  "blocking",
+  "asynk-sqlx",
+  "derive-error",
+  "blocking-postgres",
+  "blocking-mysql",
+  "blocking-sqlite",
+  "migrations-postgres",
+  "migrations-sqlite",
+  "migrations-mysql",
+]
+asynk-postgres = ["asynk-sqlx", "sqlx?/postgres"]
+asynk-sqlite = ["asynk-sqlx", "sqlx?/sqlite"]
+asynk-mysql = ["asynk-sqlx", "sqlx?/mysql"]
+asynk-sqlx = ["asynk", "dep:sqlx"]
+asynk = ["dep:tokio", "dep:async-trait", "dep:async-recursion"]
 derive-error = ["dep:fang-derive-error"]
-blocking = ["dep:diesel", "dep:diesel-derive-enum", "dep:dotenvy", "diesel?/chrono" , "diesel?/serde_json" , "diesel?/uuid", "diesel?/r2d2"]
-blocking-postgres = [ "blocking", "diesel?/postgres"]
-blocking-sqlite = ["blocking", "diesel?/sqlite" ]
-blocking-mysql = [ "blocking", "diesel?/mysql"]
+blocking = [
+  "dep:diesel",
+  "dep:diesel-derive-enum",
+  "dep:dotenvy",
+  "diesel?/chrono",
+  "diesel?/serde_json",
+  "diesel?/uuid",
+  "diesel?/r2d2",
+]
+blocking-postgres = ["blocking", "diesel?/postgres"]
+blocking-sqlite = ["blocking", "diesel?/sqlite"]
+blocking-mysql = ["blocking", "diesel?/mysql"]
 migrations-postgres = ["migrations", "diesel?/postgres"]
 migrations-sqlite = ["migrations", "diesel?/sqlite"]
 migrations-mysql = ["migrations", "diesel?/mysql"]
@@ -33,26 +54,47 @@ migrations = ["dep:diesel_migrations", "dep:diesel"]
 
 
 [dev-dependencies]
-fang-derive-error = { version = "0.1.0"}
-diesel_migrations = { version = "2.1" , features = ["postgres", "sqlite" , "mysql"]}
-sqlx = {version = "0.6.3", features = ["any" , "macros" , "chrono", "uuid", "json","runtime-tokio-rustls", "postgres", "sqlite", "mysql"]}
+fang-derive-error = { version = "0.1.0" }
+diesel_migrations = { version = "2.1", features = [
+  "postgres",
+  "sqlite",
+  "mysql",
+] }
+sqlx = { version = "0.6.3", features = [
+  "any",
+  "macros",
+  "chrono",
+  "uuid",
+  "json",
+  "runtime-tokio-rustls",
+  "postgres",
+  "sqlite",
+  "mysql",
+] }
 #console-subscriber = "0.2.0" # for tokio tracing debug
 
 [dependencies]
-cron = "0.12"
+cron = "0.17"
 chrono = "0.4"
 hex = "0.4"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sha2 = "0.10"
-thiserror = "1.0"
-typed-builder = "0.14"
+sha2 = "0.11"
+thiserror = "2"
+typed-builder = "0.23"
 typetag = "0.2"
 uuid = { version = "1.1", features = ["v4"] }
-fang-derive-error = { version = "0.1.0" , optional = true}
-sqlx = {version = "0.6.3", features = ["any" , "macros" , "chrono", "uuid", "json", "runtime-tokio-rustls"], optional = true}
+fang-derive-error = { version = "0.1.0", optional = true }
+sqlx = { version = "0.6.3", features = [
+  "any",
+  "macros",
+  "chrono",
+  "uuid",
+  "json",
+  "runtime-tokio-rustls",
+], optional = true }
 
 [dependencies.diesel]
 version = "2.1"
@@ -70,7 +112,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.25"
-features = ["rt", "time", "macros"]#, "tracing"]
+features = ["rt", "time", "macros"] #, "tracing"]
 optional = true
 
 [dependencies.async-trait]

--- a/fang/fang_examples/asynk/simple_async_worker/Cargo.toml
+++ b/fang/fang_examples/asynk/simple_async_worker/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fang = { path = "../../../" , features = ["asynk-postgres", "migrations-postgres"]}
-env_logger = "0.9.0"
+fang = { path = "../../../", features = [
+  "asynk-postgres",
+  "migrations-postgres",
+] }
+env_logger = "0.11"
 log = "0.4.0"
 dotenvy = "0.15"
-diesel = {version = "2.1" , features = ["postgres"]}
+diesel = { version = "2.1", features = ["postgres"] }
 tokio = { version = "1", features = ["full"] }

--- a/fang/fang_examples/asynk/simple_cron_async_worker/Cargo.toml
+++ b/fang/fang_examples/asynk/simple_cron_async_worker/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fang = { path = "../../../" , features = ["asynk-postgres"]}
-env_logger = "0.9.0"
+fang = { path = "../../../", features = ["asynk-postgres"] }
+env_logger = "0.11"
 log = "0.4.0"
 dotenvy = "0.15"
 tokio = { version = "1", features = ["full"] }

--- a/fang/fang_examples/asynk/simple_cron_async_worker/src/lib.rs
+++ b/fang/fang_examples/asynk/simple_cron_async_worker/src/lib.rs
@@ -31,3 +31,28 @@ impl AsyncRunnable for MyCronTask {
         true
     }
 }
+
+#[derive(Serialize, Deserialize)]
+#[serde(crate = "fang::serde")]
+pub struct MyEveryNSecsCronTask {
+    pub every_n_secs: u32,
+}
+
+#[async_trait]
+#[typetag::serde]
+impl AsyncRunnable for MyEveryNSecsCronTask {
+    async fn run(&self, _queue: &dyn AsyncQueueable) -> Result<(), FangError> {
+        log::info!("CRON!!!!!!!!!!!!!!!",);
+
+        Ok(())
+    }
+
+    fn cron(&self) -> Option<Scheduled> {
+        let expression = format!("0/{} * * * * * *", self.every_n_secs);
+        Some(Scheduled::CronPattern(expression))
+    }
+
+    fn uniq(&self) -> bool {
+        true
+    }
+}

--- a/fang/fang_examples/asynk/simple_cron_async_worker/src/main.rs
+++ b/fang/fang_examples/asynk/simple_cron_async_worker/src/main.rs
@@ -3,7 +3,7 @@ use fang::asynk::async_queue::AsyncQueue;
 use fang::asynk::async_queue::AsyncQueueable;
 use fang::asynk::async_worker_pool::AsyncWorkerPool;
 use fang::AsyncRunnable;
-use simple_cron_async_worker::MyCronTask;
+use simple_cron_async_worker::{MyCronTask, MyEveryNSecsCronTask};
 use std::env;
 use std::time::Duration;
 
@@ -39,6 +39,18 @@ async fn main() {
         .schedule_task(&task as &dyn AsyncRunnable)
         .await
         .unwrap();
+
+    let task = MyEveryNSecsCronTask { every_n_secs: 30 };
+
+    queue
+        .schedule_task(&task as &dyn AsyncRunnable)
+        .await
+        .unwrap();
+
+    log::info!(
+        "Every {} seconds task scheduled from main ...",
+        task.every_n_secs
+    );
 
     tokio::time::sleep(Duration::from_secs(100)).await;
 }

--- a/fang/fang_examples/blocking/simple_cron_worker/Cargo.toml
+++ b/fang/fang_examples/blocking/simple_cron_worker/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fang = { path = "../../../" , features = ["blocking"]}
+fang = { path = "../../../", features = ["blocking"] }
 dotenvy = "0.15"
-env_logger = "0.9.0"
+env_logger = "0.11"
 log = "0.4.0"
 diesel = { version = "2", features = ["postgres", "r2d2"] }

--- a/fang/fang_examples/blocking/simple_worker/Cargo.toml
+++ b/fang/fang_examples/blocking/simple_worker/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fang = { path = "../../../" , features = ["blocking"]}
+fang = { path = "../../../", features = ["blocking"] }
 dotenvy = "0.15"
-env_logger = "0.9.0"
+env_logger = "0.11"
 log = "0.4.0"
 diesel = { version = "2", features = ["postgres", "r2d2"] }

--- a/fang/src/asynk/async_queue.rs
+++ b/fang/src/asynk/async_queue.rs
@@ -141,15 +141,12 @@ pub trait AsyncQueueable: Send + Sync {
 /// To connect an `AsyncQueue` to PostgreSQL database call the `connect` method.
 /// A Queue can be created with the TypedBuilder.
 ///
-///    ```rust
-///         let mut queue = AsyncQueue::builder()
-///             .uri("postgres://postgres:postgres@localhost/fang")
-///             .max_pool_size(max_pool_size)
-///             .build();
-///     ```
-///
-///
-
+/// ```
+/// let mut queue = AsyncQueue::builder()
+///   .uri("postgres://postgres:postgres@localhost/fang")
+///   .max_pool_size(max_pool_size)
+///   .build();
+/// ```
 #[derive(Debug, Clone)]
 pub(crate) enum InternalPool {
     #[cfg(feature = "asynk-postgres")]

--- a/fang/src/asynk/async_runnable.rs
+++ b/fang/src/asynk/async_runnable.rs
@@ -56,15 +56,13 @@ pub trait AsyncRunnable: Send + Sync {
     /// Example:
     ///
     ///
-    /**
-    ```rust
-     fn cron(&self) -> Option<Scheduled> {
-         let expression = "0/20 * * * Aug-Sep * 2022/1";
-         Some(Scheduled::CronPattern(expression.to_string()))
-     }
-    ```
-    */
-
+    /// ```
+    /// fn cron(&self) -> Option<Scheduled> {
+    ///  let expression = "0/20 * * * Aug-Sep * 2022/1";
+    ///  Some(Scheduled::CronPattern(expression.to_string()))
+    /// }
+    /// ```
+    ///
     /// In order to schedule  a task once, use the `Scheduled::ScheduleOnce` enum variant.
     fn cron(&self) -> Option<Scheduled> {
         None

--- a/fang/src/blocking/queue.rs
+++ b/fang/src/blocking/queue.rs
@@ -117,21 +117,19 @@ pub trait Queueable {
 /// To connect a `Queue` to the PostgreSQL database call the `get_connection` method.
 /// A Queue can be created with the TypedBuilder.
 ///
-///    ```rust
-///         // Set DATABASE_URL enviroment variable if you would like to try this function.
-///         pub fn connection_pool(pool_size: u32) -> r2d2::Pool<r2d2::ConnectionManager<PgConnection>> {
-///             let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// ```rust
+/// // Set DATABASE_URL enviroment variable if you would like to try this function.
+/// pub fn connection_pool(pool_size: u32) -> r2d2::Pool<r2d2::ConnectionManager<PgConnection>> {
+///   let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+///   let manager = r2d2::ConnectionManager::<PgConnection>::new(database_url);
+///   r2d2::Pool::builder()
+///     .max_size(pool_size)
+///     .build(manager)
+///     .unwrap()
+/// }
 ///
-///             let manager = r2d2::ConnectionManager::<PgConnection>::new(database_url);
-///
-///             r2d2::Pool::builder()
-///             .max_size(pool_size)
-///             .build(manager)
-///             .unwrap()
-///         }
-///
-///         let queue = Queue::builder().connection_pool(connection_pool(3)).build();
-///     ```
+/// let queue = Queue::builder().connection_pool(connection_pool(3)).build();
+/// ```
 ///
 #[derive(Clone, TypedBuilder)]
 pub struct Queue {

--- a/fang/src/blocking/runnable.rs
+++ b/fang/src/blocking/runnable.rs
@@ -26,14 +26,14 @@ pub trait Runnable {
     /// This method defines if a task is periodic or it should be executed once in the future.
     ///
     /// Be careful it works only with the UTC timezone.
-    /**
-    ```rust
-      fn cron(&self) -> Option<Scheduled> {
-          let expression = "0/20 * * * Aug-Sep * 2022/1";
-          Some(Scheduled::CronPattern(expression.to_string()))
-      }
-     ```
-     */
+    ///
+    /// ```
+    /// fn cron(&self) -> Option<Scheduled> {
+    ///   let expression = "0/20 * * * Aug-Sep * 2022/1";
+    ///   Some(Scheduled::CronPattern(expression.to_string()))
+    /// }
+    /// ```
+    ///
     /// In order to schedule  a task once, use the `Scheduled::ScheduleOnce` enum variant.
     fn cron(&self) -> Option<Scheduled> {
         None

--- a/fang/src/blocking/worker.rs
+++ b/fang/src/blocking/worker.rs
@@ -435,7 +435,6 @@ mod worker_tests {
 
     #[test]
     #[ignore]
-
     fn no_schedule_until_run() {
         let task = TaskScheduled {};
 


### PR DESCRIPTION
Bumping deps (excluding `sqlx`  - which might require more effort and maybe makes sense to build on the existing PR draft #159 , i.e. finish it but target version `0.9` already).

Extending async cron example.

Making `cargo doc` and `cargo clippy` happy.

Example of a succeeding workflow in my fork: https://github.com/rustworthy/fang/actions/runs/28330219447

---

That's a first step with regard to #160 , but should beneficial (hopefully) as  a standalone update.