### PR TITLE
Bump sqlx to 0.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -251,3 +251,25 @@ jobs:
 
       - name: Run tests
         run: cargo test "asynk::async_queue::mysql" --verbose --features asynk-mysql --color always -- --nocapture
+
+  # check that we can build using the minimal rust
+  # version (MSRV) that is specified by this crate
+  msrv:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          # home@0.5.12 (which is sqlx dependency) requires rustc 1.88
+          msrv: ["1.88.0"]
+      name: ubuntu / ${{ matrix.msrv }}
+      steps:
+        - uses: actions/checkout@v7
+        - name: Install ${{ matrix.msrv }}
+          uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ matrix.msrv }}
+        # Note how we are not passing `--all-targets` here unlike other places in he linting
+        # and testing workflows. This is because the whole point of the MSRV cecking is to
+        # ensure that the crate "can be built" with a Rust version equal to the specified MSRV.
+        # There is no obligation to ensure this for such targets as tests and examples.
+        - name: cargo +${{ matrix.msrv }} check --all-features
+          run: cargo check --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.0-rc2 - unreleased
+
+- add `msrv` job to CI, pin `1.88` as MSRV - [#162]
+- update `sqlx` from `0.6` to `0.8` - [#162]
+- update `cron` from `0.12` to `1.17` - [#161]
+- update `sha` from `0.10` to `0.11` - [#161]
+- update `thiserror` from `1` to `2` - [#161]
+- update `typed-builder` from `0.14` to `0.23` - [#161]
+
+[#161]: https://github.com/ayrat555/fang/pull/161
+[#162]: https://github.com/ayrat555/fang/pull/162
 ## 0.11.0-rc1 (2024-04-22)
 
 - Fix blocking features - [#151](https://github.com/ayrat555/fang/pull/151)

--- a/fang/Cargo.toml
+++ b/fang/Cargo.toml
@@ -60,7 +60,7 @@ diesel_migrations = { version = "2.1", features = [
   "sqlite",
   "mysql",
 ] }
-sqlx = { version = "0.6.3", features = [
+sqlx = { version = "0.8", features = [
   "any",
   "macros",
   "chrono",
@@ -86,8 +86,9 @@ thiserror = "2"
 typed-builder = "0.23"
 typetag = "0.2"
 uuid = { version = "1.1", features = ["v4"] }
+url = "2"
 fang-derive-error = { version = "0.1.0", optional = true }
-sqlx = { version = "0.6.3", features = [
+sqlx = { version = "0.8", features = [
   "any",
   "macros",
   "chrono",

--- a/fang/src/asynk/async_queue.rs
+++ b/fang/src/asynk/async_queue.rs
@@ -13,18 +13,17 @@ use async_trait::async_trait;
 use chrono::DateTime;
 use chrono::Utc;
 use cron::Schedule;
-use sqlx::any::AnyConnectOptions;
-use sqlx::any::AnyKind;
+use sqlx::any::install_default_drivers;
 #[cfg(any(
     feature = "asynk-postgres",
     feature = "asynk-mysql",
     feature = "asynk-sqlite"
 ))]
 use sqlx::pool::PoolOptions;
-//use sqlx::any::install_default_drivers; // this is supported in sqlx 0.7
 use std::str::FromStr;
 use thiserror::Error;
 use typed_builder::TypedBuilder;
+use url::Url;
 use uuid::Uuid;
 
 #[cfg(feature = "asynk-postgres")]
@@ -53,6 +52,8 @@ pub enum AsyncQueueError {
     SqlXError(#[from] sqlx::Error),
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
+    #[error(transparent)]
+    DatabaseUrlParseError(#[from] url::ParseError),
     #[error(transparent)]
     CronError(#[from] CronError),
     #[error("returned invalid result (expected {expected:?}, found {found:?})")]
@@ -234,40 +235,37 @@ use std::env;
 
 use super::backend_sqlx::BackendSqlX;
 
-async fn get_pool(
-    kind: AnyKind,
-    _uri: &str,
-    _max_connections: u32,
-) -> Result<InternalPool, AsyncQueueError> {
-    match kind {
+async fn get_pool(uri: &Url, max_connections: u32) -> Result<InternalPool, AsyncQueueError> {
+    match uri.scheme() {
+        // https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
         #[cfg(feature = "asynk-postgres")]
-        AnyKind::Postgres => {
+        "postgres" | "postgresql" => {
             let pool = PoolOptions::<Postgres>::new()
-                .max_connections(_max_connections)
-                .connect(_uri)
+                .max_connections(max_connections)
+                .connect(uri.as_str())
                 .await?;
 
             Ok(InternalPool::Pg(pool))
         }
         #[cfg(feature = "asynk-mysql")]
-        AnyKind::MySql => {
+        // https://dev.mysql.com/doc/refman/9.7/en/connecting-using-uri-or-key-value-pairs.html
+        "mysql" | "mysqlx" => {
             let pool = PoolOptions::<MySql>::new()
-                .max_connections(_max_connections)
-                .connect(_uri)
+                .max_connections(max_connections)
+                .connect(uri.as_str())
                 .await?;
 
             Ok(InternalPool::MySql(pool))
         }
         #[cfg(feature = "asynk-sqlite")]
-        AnyKind::Sqlite => {
+        "sqlite" => {
             let pool = PoolOptions::<Sqlite>::new()
-                .max_connections(_max_connections)
-                .connect(_uri)
+                .max_connections(max_connections)
+                .connect(uri.as_str())
                 .await?;
 
             Ok(InternalPool::Sqlite(pool))
         }
-        #[allow(unreachable_patterns)]
         _ => Err(AsyncQueueError::ConnectionError),
     }
 }
@@ -284,11 +282,11 @@ impl AsyncQueue {
 
     /// Connect to the db if not connected
     pub async fn connect(&mut self) -> Result<(), AsyncQueueError> {
-        //install_default_drivers();
+        install_default_drivers();
 
-        let kind: AnyKind = self.uri.parse::<AnyConnectOptions>()?.kind();
+        let database_url = Url::parse(&self.uri).map_err(AsyncQueueError::DatabaseUrlParseError)?;
 
-        let pool = get_pool(kind, &self.uri, self.max_pool_size).await?;
+        let pool = get_pool(&database_url, self.max_pool_size).await?;
 
         self.pool = pool;
         self.connected = true;

--- a/fang/src/asynk/backend_sqlx.rs
+++ b/fang/src/asynk/backend_sqlx.rs
@@ -2,8 +2,8 @@ use chrono::{DateTime, Utc};
 use sha2::Digest;
 use sha2::Sha256;
 use {
-    chrono::Duration, sqlx::any::AnyQueryResult, sqlx::database::HasArguments, sqlx::Database,
-    sqlx::Encode, sqlx::Executor, sqlx::FromRow, sqlx::IntoArguments, sqlx::Pool, sqlx::Type,
+    chrono::Duration, sqlx::any::AnyQueryResult, sqlx::Database, sqlx::Encode, sqlx::Executor,
+    sqlx::FromRow, sqlx::IntoArguments, sqlx::Pool, sqlx::Type,
 };
 
 use std::fmt::Debug;
@@ -155,7 +155,7 @@ where
     for<'r> &'r Uuid: Encode<'r, DB> + Type<DB>,
     for<'r> &'r serde_json::Value: Encode<'r, DB> + Type<DB>,
     for<'r> &'r Pool<DB>: Executor<'r, Database = DB>,
-    for<'r> <DB as HasArguments<'r>>::Arguments: IntoArguments<'r, DB>,
+    for<'r> <DB as Database>::Arguments<'r>: IntoArguments<'r, DB>,
     <DB as Database>::QueryResult: Into<AnyQueryResult>,
 {
     async fn fetch_task_type(


### PR DESCRIPTION
Bumping `sqlx` from 0.6 to 0.8. A bump to the latest `sqlx` (0.9) will be in a follow-up. This MR is inspired by the pending #159 and will probably supersede it.

Also adding a MSRV job to CI. This is currently `1.88`, but once we migrate to the latest sqlx will be `1.94`  (https://github.com/transact-rs/sqlx/blob/3da582ad1dca5054ec8eda1c87b3b16ca079f47a/CHANGELOG.md#breaking).

Example of passing pipeline in my fork: https://github.com/rustworthy/fang/actions/runs/28466377759